### PR TITLE
add metro door system/update fit version 3095

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,4 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
-server/server.lua
+

--- a/__resource.lua
+++ b/__resource.lua
@@ -3,5 +3,8 @@ client_scripts {
 	'client/config.lua',
 	'client/client.lua'
 }
+server_scripts {
+	'server/server.lua'
+}
 
 export 'createTrain'

--- a/client/client.lua
+++ b/client/client.lua
@@ -143,7 +143,7 @@ Citizen.CreateThread(function()
 			SetBlipColour (blip, 2)
 			SetBlipAsShortRange(blip, true)
 			BeginTextCommandSetBlipName("STRING")
-			AddTextComponentString("驾驶火车")
+			AddTextComponentString("train")
 			EndTextCommandSetBlipName(blip)
 		end
 		-- Log("Done Loading Train Blips.")
@@ -160,40 +160,21 @@ Citizen.CreateThread(function()
 	while true do
 		Citizen.Wait(0)
 		if Config.inTrain then
-			-- 开关门
+			--    
+			-- door open/close
 			local doorcount = GetTrainDoorCount(Config.TrainVeh)
 			-- -- print (doorcount)
 			if IsControlJustReleased(keyboard, 82) then
 				-- -- print (Config.TrainVeh)
 				local carrige = GetTrainCarriage(Config.TrainVeh, 1)
-				
-				-- for doorindex = 0, doorcount-1 do
-					
-				-- 	-- 控制左边门，本车的1,3，下一车的2,4
-				-- 	if doorindex == 0 or doorindex == 2 then
-				-- 		local doorstate = GetTrainDoorOpenRatio(Config.TrainVeh, doorindex)
-				-- 		if doorstate == 0.0 then
-				-- 			SetTrainDoorOpenRatio(Config.TrainVeh, doorindex, 1.0)
-				-- 		else
-				-- 			SetTrainDoorOpenRatio(Config.TrainVeh, doorindex, 0.0)
-				-- 		end
-				-- 	else
-				-- 		local doorstate = GetTrainDoorOpenRatio(carrige, doorindex)
-				-- 		if doorstate == 0.0 then
-				-- 			SetTrainDoorOpenRatio(carrige, doorindex, 1.0)
-				-- 		else
-				-- 			SetTrainDoorOpenRatio(carrige, doorindex, 0.0)
-				-- 		end
-				-- 	end
 
-				-- end
-				
-				--动画，逐渐开门
+				-- smoothly open door in animation	
 				local serverid = GetPlayerServerId(PlayerId())
 				local doorstate = GetTrainDoorOpenRatio(Config.TrainVeh, 0)
 				if doorstate <=0.05 then
-					--逐渐开门
-					--让其他玩家看到开门动画
+					--    
+					--           
+					-- let other players see the door opening animation	
 					TriggerServerEvent('Train:opendoor', 1, NetworkGetNetworkIdFromEntity(Config.TrainVeh), NetworkGetNetworkIdFromEntity(carrige), serverid)
 					while doorstate <= 1.0 do
 						SetTrainDoorOpenRatio(Config.TrainVeh, 0, doorstate)
@@ -204,8 +185,8 @@ Citizen.CreateThread(function()
 						Citizen.Wait(2)
 					end
 				else
-					--逐渐关门
-					--让其他玩家看到关门动画
+					--    
+					--           
 					TriggerServerEvent('Train:closeDoor', 1, NetworkGetNetworkIdFromEntity(Config.TrainVeh), NetworkGetNetworkIdFromEntity(carrige), serverid)
 					while doorstate >= 0.0 do
 						SetTrainDoorOpenRatio(Config.TrainVeh, 0, doorstate)
@@ -219,35 +200,14 @@ Citizen.CreateThread(function()
 
 			elseif IsControlJustReleased(keyboard, 81) then
 				local carrige = GetTrainCarriage(Config.TrainVeh, 1)
-				-- for doorindex = 0, doorcount-1 do
-					
-				-- 	-- 控制右边门，本车的2,4，下一车的1,3
-					
-				-- 	if doorindex == 1 or doorindex == 3 then
-				-- 		local doorstate = GetTrainDoorOpenRatio(Config.TrainVeh, doorindex)
-				-- 		if doorstate == 0.0 then
-				-- 			SetTrainDoorOpenRatio(Config.TrainVeh, doorindex, 1.0)
-				-- 		else
-				-- 			SetTrainDoorOpenRatio(Config.TrainVeh, doorindex, 0.0)
-				-- 		end
-				-- 	else
-				-- 		local doorstate = GetTrainDoorOpenRatio(carrige, doorindex)
-				-- 		if doorstate == 0.0 then
-				-- 			SetTrainDoorOpenRatio(carrige, doorindex, 1.0)
-				-- 		else
-				-- 			SetTrainDoorOpenRatio(carrige, doorindex, 0.0)
-				-- 		end
-				-- 	end	
-				-- end
 
-				--动画，逐渐开门
 				local doorstate = GetTrainDoorOpenRatio(Config.TrainVeh, 1)
 				local serverid = GetPlayerServerId(PlayerId())
 				if doorstate <=0.05 then
 					-- print (Config.TrainVeh .. " " .. carrige)
 					-- print (NetworkGetNetworkIdFromEntity(Config.TrainVeh) .. " " .. NetworkGetNetworkIdFromEntity(carrige))
-					--逐渐开门
-					--让其他玩家看到开门动画	
+					--    
+					--           	
 					TriggerServerEvent('Train:opendoor', 0, NetworkGetNetworkIdFromEntity(Config.TrainVeh), NetworkGetNetworkIdFromEntity(carrige), serverid)
 					while doorstate <= 1.0 do
 						
@@ -263,8 +223,8 @@ Citizen.CreateThread(function()
 					SetVehicleDoorOpen(carrige, 0, false, false)
 					SetVehicleDoorOpen(carrige, 2, false, false)
 				else
-					--逐渐关门
-					--让其他玩家看到关门动画
+					--    
+					--           
 					TriggerServerEvent('Train:closeDoor', 0, NetworkGetNetworkIdFromEntity(Config.TrainVeh), NetworkGetNetworkIdFromEntity(carrige), serverid)
 					while doorstate >= 0.0 do
 						SetTrainDoorOpenRatio(Config.TrainVeh, 1, doorstate)
@@ -291,7 +251,8 @@ AddEventHandler('Train:opendoor', function(direction,trainnetworkid,carrigenetwo
 	if not NetworkDoesEntityExistWithNetworkId(trainnetworkid) or not NetworkDoesEntityExistWithNetworkId(carrigenetworkid) then
 		return
 	end
-	-- 如果是自己，返回
+	--      ，  
+	-- if self, return
 	if serverid == GetPlayerServerId(PlayerId()) then
 		return
 	end
@@ -300,7 +261,8 @@ AddEventHandler('Train:opendoor', function(direction,trainnetworkid,carrigenetwo
 	local carrige = NetworkGetEntityFromNetworkId(carrigenetworkid)
 	-- print (type(direction))
 	-- print (train ..DoesEntityExist(train) ..  " " .. carrige .. DoesEntityExist(carrige))
-	-- direction true左边，false右边
+	-- direction true  ，false  
+	-- direction true left, false right
 	local doorstate = 0.0
 	if direction == 1 then
 		-- print ("open left")
@@ -336,7 +298,7 @@ AddEventHandler('Train:closeDoor', function(direction,trainnetworkid,carrigenetw
 	-- print (type(direction))
 	local train = NetworkGetEntityFromNetworkId(trainnetworkid)
 	local carrige = NetworkGetEntityFromNetworkId(carrigenetworkid)
-	-- direction true左边，false右边
+	-- direction true  ，false  
 	local doorstate = 1.0
 	-- print (train .. DoesEntityExist(train) .. " " .. carrige .. DoesEntityExist(carrige))
 	if direction == 1 then

--- a/client/client.lua
+++ b/client/client.lua
@@ -1,4 +1,4 @@
-if (Config.Debug) then
+if (true) then
 	Citizen.CreateThread(function()
 		Log("Train Markers Init.")
 		while true do		
@@ -128,12 +128,13 @@ Citizen.CreateThread(function()
 		RequestModelSync("metrotrain")
 		RequestModelSync("s_m_m_lsmetro_01")
 		Log("Done Loading Train Models.")
+		-- print ("Done Loading Train Models.")
 		Config.ModelsLoaded = true
 	end
 	LoadTrainModels()
 	
-	if (Config.Debug) then
-		Log("Loading Train Blips.")
+	if (true) then
+		-- Log("Loading Train Blips.")
 		for i=1, #Config.TrainLocations, 1 do
 			local blip = AddBlipForCoord(Config.TrainLocations[i].x, Config.TrainLocations[i].y, Config.TrainLocations[i].z)      
 			SetBlipSprite (blip, Config.BlipSprite)
@@ -142,14 +143,219 @@ Citizen.CreateThread(function()
 			SetBlipColour (blip, 2)
 			SetBlipAsShortRange(blip, true)
 			BeginTextCommandSetBlipName("STRING")
-			AddTextComponentString("Trains")
+			AddTextComponentString("驾驶火车")
 			EndTextCommandSetBlipName(blip)
 		end
-		Log("Done Loading Train Blips.")
+		-- Log("Done Loading Train Blips.")
 	end
 	
 	while true do
 		Wait(0)
 		doTrains()
+	end
+end)
+
+Citizen.CreateThread(function()
+	SetTrainsForceDoorsOpen(0)
+	while true do
+		Citizen.Wait(0)
+		if Config.inTrain then
+			-- 开关门
+			local doorcount = GetTrainDoorCount(Config.TrainVeh)
+			-- -- print (doorcount)
+			if IsControlJustReleased(keyboard, 82) then
+				-- -- print (Config.TrainVeh)
+				local carrige = GetTrainCarriage(Config.TrainVeh, 1)
+				
+				-- for doorindex = 0, doorcount-1 do
+					
+				-- 	-- 控制左边门，本车的1,3，下一车的2,4
+				-- 	if doorindex == 0 or doorindex == 2 then
+				-- 		local doorstate = GetTrainDoorOpenRatio(Config.TrainVeh, doorindex)
+				-- 		if doorstate == 0.0 then
+				-- 			SetTrainDoorOpenRatio(Config.TrainVeh, doorindex, 1.0)
+				-- 		else
+				-- 			SetTrainDoorOpenRatio(Config.TrainVeh, doorindex, 0.0)
+				-- 		end
+				-- 	else
+				-- 		local doorstate = GetTrainDoorOpenRatio(carrige, doorindex)
+				-- 		if doorstate == 0.0 then
+				-- 			SetTrainDoorOpenRatio(carrige, doorindex, 1.0)
+				-- 		else
+				-- 			SetTrainDoorOpenRatio(carrige, doorindex, 0.0)
+				-- 		end
+				-- 	end
+
+				-- end
+				
+				--动画，逐渐开门
+				local serverid = GetPlayerServerId(PlayerId())
+				local doorstate = GetTrainDoorOpenRatio(Config.TrainVeh, 0)
+				if doorstate <=0.05 then
+					--逐渐开门
+					--让其他玩家看到开门动画
+					TriggerServerEvent('Train:opendoor', 1, NetworkGetNetworkIdFromEntity(Config.TrainVeh), NetworkGetNetworkIdFromEntity(carrige), serverid)
+					while doorstate <= 1.0 do
+						SetTrainDoorOpenRatio(Config.TrainVeh, 0, doorstate)
+						SetTrainDoorOpenRatio(Config.TrainVeh, 2, doorstate)
+						SetTrainDoorOpenRatio(carrige, 1, doorstate)
+						SetTrainDoorOpenRatio(carrige, 3, doorstate)	
+						doorstate = doorstate + 0.01
+						Citizen.Wait(2)
+					end
+				else
+					--逐渐关门
+					--让其他玩家看到关门动画
+					TriggerServerEvent('Train:closeDoor', 1, NetworkGetNetworkIdFromEntity(Config.TrainVeh), NetworkGetNetworkIdFromEntity(carrige), serverid)
+					while doorstate >= 0.0 do
+						SetTrainDoorOpenRatio(Config.TrainVeh, 0, doorstate)
+						SetTrainDoorOpenRatio(Config.TrainVeh, 2, doorstate)
+						SetTrainDoorOpenRatio(carrige, 1, doorstate)
+						SetTrainDoorOpenRatio(carrige, 3, doorstate)	
+						doorstate = doorstate - 0.01
+						Citizen.Wait(2)
+					end
+				end
+
+			elseif IsControlJustReleased(keyboard, 81) then
+				local carrige = GetTrainCarriage(Config.TrainVeh, 1)
+				-- for doorindex = 0, doorcount-1 do
+					
+				-- 	-- 控制右边门，本车的2,4，下一车的1,3
+					
+				-- 	if doorindex == 1 or doorindex == 3 then
+				-- 		local doorstate = GetTrainDoorOpenRatio(Config.TrainVeh, doorindex)
+				-- 		if doorstate == 0.0 then
+				-- 			SetTrainDoorOpenRatio(Config.TrainVeh, doorindex, 1.0)
+				-- 		else
+				-- 			SetTrainDoorOpenRatio(Config.TrainVeh, doorindex, 0.0)
+				-- 		end
+				-- 	else
+				-- 		local doorstate = GetTrainDoorOpenRatio(carrige, doorindex)
+				-- 		if doorstate == 0.0 then
+				-- 			SetTrainDoorOpenRatio(carrige, doorindex, 1.0)
+				-- 		else
+				-- 			SetTrainDoorOpenRatio(carrige, doorindex, 0.0)
+				-- 		end
+				-- 	end	
+				-- end
+
+				--动画，逐渐开门
+				local doorstate = GetTrainDoorOpenRatio(Config.TrainVeh, 1)
+				local serverid = GetPlayerServerId(PlayerId())
+				if doorstate <=0.05 then
+					-- print (Config.TrainVeh .. " " .. carrige)
+					-- print (NetworkGetNetworkIdFromEntity(Config.TrainVeh) .. " " .. NetworkGetNetworkIdFromEntity(carrige))
+					--逐渐开门
+					--让其他玩家看到开门动画	
+					TriggerServerEvent('Train:opendoor', 0, NetworkGetNetworkIdFromEntity(Config.TrainVeh), NetworkGetNetworkIdFromEntity(carrige), serverid)
+					while doorstate <= 1.0 do
+						
+						SetTrainDoorOpenRatio(Config.TrainVeh, 1, doorstate)
+						SetTrainDoorOpenRatio(Config.TrainVeh, 3, doorstate)
+						SetTrainDoorOpenRatio(carrige, 0, doorstate)
+						SetTrainDoorOpenRatio(carrige, 2, doorstate)	
+						doorstate = doorstate + 0.01
+						Citizen.Wait(1)
+					end
+					SetVehicleDoorOpen(Config.TrainVeh, 3, false, false)
+					SetVehicleDoorOpen(Config.TrainVeh, 1, false, false)
+					SetVehicleDoorOpen(carrige, 0, false, false)
+					SetVehicleDoorOpen(carrige, 2, false, false)
+				else
+					--逐渐关门
+					--让其他玩家看到关门动画
+					TriggerServerEvent('Train:closeDoor', 0, NetworkGetNetworkIdFromEntity(Config.TrainVeh), NetworkGetNetworkIdFromEntity(carrige), serverid)
+					while doorstate >= 0.0 do
+						SetTrainDoorOpenRatio(Config.TrainVeh, 1, doorstate)
+						SetTrainDoorOpenRatio(Config.TrainVeh, 3, doorstate)
+						SetTrainDoorOpenRatio(carrige, 0, doorstate)
+						SetTrainDoorOpenRatio(carrige, 2, doorstate)	
+						doorstate = doorstate - 0.01
+						Citizen.Wait(1)
+					end
+					SetVehicleDoorShut(Config.TrainVeh, 3, false)
+					SetVehicleDoorShut(Config.TrainVeh, 1, false)
+					SetVehicleDoorShut(carrige, 0, false)
+					SetVehicleDoorShut(carrige, 2, false)
+				end
+			end
+
+					
+		end
+	end
+end)
+
+RegisterNetEvent('Train:opendoor')
+AddEventHandler('Train:opendoor', function(direction,trainnetworkid,carrigenetworkid, serverid )
+	if not NetworkDoesEntityExistWithNetworkId(trainnetworkid) or not NetworkDoesEntityExistWithNetworkId(carrigenetworkid) then
+		return
+	end
+	-- 如果是自己，返回
+	if serverid == GetPlayerServerId(PlayerId()) then
+		return
+	end
+	-- print (direction .. " " .. trainnetworkid .. " " .. carrigenetworkid)
+	local train = NetworkGetEntityFromNetworkId(trainnetworkid)
+	local carrige = NetworkGetEntityFromNetworkId(carrigenetworkid)
+	-- print (type(direction))
+	-- print (train ..DoesEntityExist(train) ..  " " .. carrige .. DoesEntityExist(carrige))
+	-- direction true左边，false右边
+	local doorstate = 0.0
+	if direction == 1 then
+		-- print ("open left")
+		while doorstate <= 1.0 do
+			SetTrainDoorOpenRatio(train, 0, doorstate)
+			SetTrainDoorOpenRatio(train, 2, doorstate)
+			SetTrainDoorOpenRatio(carrige, 1, doorstate)
+			SetTrainDoorOpenRatio(carrige, 3, doorstate)	
+			doorstate = doorstate + 0.01
+			Citizen.Wait(2)
+		end
+	else
+		-- print ("open right")
+		while doorstate <= 1.0 do
+			SetTrainDoorOpenRatio(train, 1, doorstate)
+			SetTrainDoorOpenRatio(train, 3, doorstate)
+			SetTrainDoorOpenRatio(carrige, 0, doorstate)
+			SetTrainDoorOpenRatio(carrige, 2, doorstate)	
+			doorstate = doorstate + 0.01
+			Citizen.Wait(2)
+		end
+	end
+end)
+RegisterNetEvent('Train:closeDoor')
+AddEventHandler('Train:closeDoor', function(direction,trainnetworkid,carrigenetworkid,serverid)
+	if not NetworkDoesEntityExistWithNetworkId(trainnetworkid) or not NetworkDoesEntityExistWithNetworkId(carrigenetworkid) then
+		return
+	end
+	if serverid == GetPlayerServerId(PlayerId()) then
+		return
+	end
+	-- print (direction .. " " .. trainnetworkid .. " " .. carrigenetworkid)
+	-- print (type(direction))
+	local train = NetworkGetEntityFromNetworkId(trainnetworkid)
+	local carrige = NetworkGetEntityFromNetworkId(carrigenetworkid)
+	-- direction true左边，false右边
+	local doorstate = 1.0
+	-- print (train .. DoesEntityExist(train) .. " " .. carrige .. DoesEntityExist(carrige))
+	if direction == 1 then
+		while doorstate >= 0.0 do
+			SetTrainDoorOpenRatio(train, 0, doorstate)
+			SetTrainDoorOpenRatio(train, 2, doorstate)
+			SetTrainDoorOpenRatio(carrige, 1, doorstate)
+			SetTrainDoorOpenRatio(carrige, 3, doorstate)	
+			doorstate = doorstate - 0.01
+			Citizen.Wait(2)
+		end
+	else
+		while doorstate >= 0.0 do
+			SetTrainDoorOpenRatio(train, 1, doorstate)
+			SetTrainDoorOpenRatio(train, 3, doorstate)
+			SetTrainDoorOpenRatio(carrige, 0, doorstate)
+			SetTrainDoorOpenRatio(carrige, 2, doorstate)	
+			doorstate = doorstate - 0.01
+			Citizen.Wait(2)
+		end
 	end
 end)

--- a/client/client.lua
+++ b/client/client.lua
@@ -1,4 +1,4 @@
-if (true) then
+if (Config.Debug) then
 	Citizen.CreateThread(function()
 		Log("Train Markers Init.")
 		while true do		
@@ -128,13 +128,12 @@ Citizen.CreateThread(function()
 		RequestModelSync("metrotrain")
 		RequestModelSync("s_m_m_lsmetro_01")
 		Log("Done Loading Train Models.")
-		-- print ("Done Loading Train Models.")
 		Config.ModelsLoaded = true
 	end
 	LoadTrainModels()
 	
-	if (true) then
-		-- Log("Loading Train Blips.")
+	if (Config.Debug) then
+		Log("Loading Train Blips.")
 		for i=1, #Config.TrainLocations, 1 do
 			local blip = AddBlipForCoord(Config.TrainLocations[i].x, Config.TrainLocations[i].y, Config.TrainLocations[i].z)      
 			SetBlipSprite (blip, Config.BlipSprite)
@@ -146,7 +145,7 @@ Citizen.CreateThread(function()
 			AddTextComponentString("train")
 			EndTextCommandSetBlipName(blip)
 		end
-		-- Log("Done Loading Train Blips.")
+		Log("Done Loading Train Blips.")
 	end
 	
 	while true do

--- a/client/config.lua
+++ b/client/config.lua
@@ -20,17 +20,16 @@ Config.Debug = false
 
 -- Marker/Blip Locations/Spawn locations
 Config.TrainLocations = {
-	{ ['x'] = 247.965,  ['y'] = -1201.17,  ['z'] = 38.92, ['trainID'] = 24, ['trainX'] = 247.9364, ['trainY'] = -1198.597, ['trainZ'] = 37.4482 }, -- Trolley
-	{ ['x'] = 670.2056,  ['y'] = -685.7708,  ['z'] = 25.15311, ['trainID'] = 23, ['trainX'] = 670.2056, ['trainY'] = -685.7708, ['trainZ'] = 25.15311 }, -- FTrain
+	{ ['x'] = 247.965,  ['y'] = -1201.17,  ['z'] = 38.92, ['trainID'] = 27, ['trainX'] = 247.9364, ['trainY'] = -1198.597, ['trainZ'] = 37.4482 }, -- Trolley
+	{ ['x'] = 670.2056,  ['y'] = -685.7708,  ['z'] = 25.15311, ['trainID'] = 17, ['trainX'] = 670.2056, ['trainY'] = -685.7708, ['trainZ'] = 25.15311 }, -- FTrain
 }
 
 -- Train speeds (https://en.wikipedia.org/wiki/Rail_speed_limits_in_the_United_States)
 Config.TrainSpeeds = {
-	[1030400667] = { ["MaxSpeed"] = 36, ["Accel"] = 0.05, ["Dccel"] = 0.1, ["Pass"] = false }, -- F Trains
-	[868868440] = { ["MaxSpeed"] = 91, ["Accel"] = 0.1, ["Dccel"] = 0.1, ["Pass"] = true }, -- T Trains
+	[1030400667] = { ["MaxSpeed"] = 75, ["Accel"] = 0.01, ["Dccel"] = 0.02, ["Pass"] = false }, -- F Trains
+	[868868440] = { ["MaxSpeed"] = 40, ["Accel"] = 0.05, ["Dccel"] = 0.07, ["Pass"] = false}, -- 地铁
 }
-
--- Utils
+ -- Utils
 function getVehicleInDirection(coordFrom, coordTo)
 	local rayHandle = CastRayPointToPoint(coordFrom.x, coordFrom.y, coordFrom.z, coordTo.x, coordTo.y, coordTo.z, 10, GetPlayerPed(-1), 0)
 	local a, b, c, d, vehicle = GetRaycastResult(rayHandle)
@@ -58,6 +57,7 @@ end
 
 function getTrainSpeeds(veh)
 	local model = GetEntityModel(veh)
+	-- print("Model: " .. model)
 	local ret = {}
 	ret.MaxSpeed = 0
 	ret.Accel = 0
@@ -84,10 +84,12 @@ function getCanPassenger(veh)
 end
 
 function createTrain(type,x,y,z)
-	local train = CreateMissionTrain(type,x,y,z,true)
+	local train = CreateMissionTrain(type,x,y,z,true,false)
 	SetTrainSpeed(train,0)
 	SetTrainCruiseSpeed(train,0)
 	SetEntityAsMissionEntity(train, true, false)
+	-- NetworkRegisterEntityAsNetworked(train)	
+	NetworkRegisterEntityAsNetworked(GetTrainCarriage( train, 1 ))
 	debugLog("createTrain.")
 end
 

--- a/client/config.lua
+++ b/client/config.lua
@@ -27,7 +27,7 @@ Config.TrainLocations = {
 -- Train speeds (https://en.wikipedia.org/wiki/Rail_speed_limits_in_the_United_States)
 Config.TrainSpeeds = {
 	[1030400667] = { ["MaxSpeed"] = 75, ["Accel"] = 0.01, ["Dccel"] = 0.02, ["Pass"] = false }, -- F Trains
-	[868868440] = { ["MaxSpeed"] = 40, ["Accel"] = 0.05, ["Dccel"] = 0.07, ["Pass"] = false}, -- 地铁
+	[868868440] = { ["MaxSpeed"] = 40, ["Accel"] = 0.05, ["Dccel"] = 0.07, ["Pass"] = false}, -- metro
 }
  -- Utils
 function getVehicleInDirection(coordFrom, coordTo)

--- a/server/server.lua
+++ b/server/server.lua
@@ -1,0 +1,24 @@
+print('TrainSportation:Server')
+RegisterNetEvent('Train:opendoor')
+AddEventHandler('Train:opendoor', function(direction,train,carrige, serverid )
+    -- direction true左边，false右边
+    print(train.. 'Train:opendoor' .. carrige)
+    if direction then
+        --触发所有玩家客户端
+        TriggerClientEvent('Train:opendoor', -1, direction,train,carrige, serverid)
+    else
+        TriggerClientEvent('Train:opendoor', -1, direction,train,carrige, serverid)
+    end
+end)
+
+RegisterNetEvent('Train:closeDoor')
+AddEventHandler('Train:closeDoor', function(direction,train,carrige, serverid )
+    print ('Train:closeDoor')
+    -- direction true左边，false右边
+    if direction then
+        --触发所有玩家客户端
+        TriggerClientEvent('Train:closeDoor', -1, direction,train,carrige, serverid)
+    else
+        TriggerClientEvent('Train:closeDoor', -1, direction,train,carrige, serverid)
+    end
+end)

--- a/server/server.lua
+++ b/server/server.lua
@@ -1,10 +1,12 @@
 print('TrainSportation:Server')
 RegisterNetEvent('Train:opendoor')
 AddEventHandler('Train:opendoor', function(direction,train,carrige, serverid )
-    -- direction true左边，false右边
+    
+    -- direction true left side, false right side
     print(train.. 'Train:opendoor' .. carrige)
     if direction then
-        --触发所有玩家客户端
+        --                  
+        -- trigger all player clients
         TriggerClientEvent('Train:opendoor', -1, direction,train,carrige, serverid)
     else
         TriggerClientEvent('Train:opendoor', -1, direction,train,carrige, serverid)
@@ -14,9 +16,9 @@ end)
 RegisterNetEvent('Train:closeDoor')
 AddEventHandler('Train:closeDoor', function(direction,train,carrige, serverid )
     print ('Train:closeDoor')
-    -- direction true左边，false右边
+   
     if direction then
-        --触发所有玩家客户端
+        --                  
         TriggerClientEvent('Train:closeDoor', -1, direction,train,carrige, serverid)
     else
         TriggerClientEvent('Train:closeDoor', -1, direction,train,carrige, serverid)


### PR DESCRIPTION
I add a lot lines of code so that 

1. this script can fit version 3095, in config.lua ,I changed trainid to 27/17 one is two car metro and the other is 40 cars train.
2. I changed config,lua train accel and dccel so that it can more fit real life.
3. most update! I added metro doors system. in client.lua,  I add a lot of code to let metro can open/close doors in a smoothly animation. players can press ","and "." to open left/right doors . when developing , I see that doors state updated in local can not be seen by other players ,so I add server.lua to let other players to see the doors open/close. we should use network id instead of entity handling to update doors states.